### PR TITLE
Adiciona método Contains e marca InArray como deprecado

### DIFF
--- a/linkedhashmap.go
+++ b/linkedhashmap.go
@@ -61,21 +61,21 @@ func (l *linkedHashMap) Put(key, value interface{}) {
 }
 
 // Get gets an entry from the linked hash map
-func (l *linkedHashMap) Get(key interface{}) interface{} {
+func (l *linkedHashMap) Get(key interface{}) (value interface{}, found bool) {
 	hash := l.hash(key)
 	if _, ok := l.table[hash]; !ok {
-		return nil
+		return nil, false
 	}
 
 	tmp := l.table[hash]
 	for tmp != nil {
 		if tmp.key == key {
-			return tmp.value
+			return tmp.value, true
 		}
 		tmp = tmp.after
 	}
 
-	return nil
+	return nil, false
 }
 
 // Remove removes an entry from the linked hash map

--- a/linkedhashmap_test.go
+++ b/linkedhashmap_test.go
@@ -12,13 +12,17 @@ func TestGet(t *testing.T) {
 		set := newLinkedHashMap()
 		value := rand.Int()
 		set.Put("test", value)
-		require.Equal(t, value, set.Get("test"))
+
+		v, exists := set.Get("test")
+		require.Equal(t, value, v)
+		require.True(t, exists)
 	})
 
 	t.Run("When the key not exists", func(t *testing.T) {
 		set := newLinkedHashMap()
-		result := set.Get("bla")
+		result, exists := set.Get("bla")
 		require.Nil(t, result)
+		require.False(t, exists)
 	})
 }
 
@@ -27,7 +31,10 @@ func TestPut(t *testing.T) {
 		set := newLinkedHashMap()
 		value := rand.Int()
 		set.Put("test", value)
-		require.Equal(t, value, set.Get("test"))
+
+		v, exists := set.Get("test")
+		require.Equal(t, value, v)
+		require.True(t, exists)
 	})
 
 	t.Run("invalid key", func(t *testing.T) {
@@ -50,7 +57,10 @@ func TestRemove(t *testing.T) {
 
 		set.Remove(1)
 		require.Equal(t, 2, set.Length())
-		require.Nil(t, set.Get(1))
+
+		v, exists := set.Get(1)
+		require.Nil(t, v)
+		require.False(t, exists)
 	})
 
 	t.Run("last value", func(t *testing.T) {
@@ -61,7 +71,10 @@ func TestRemove(t *testing.T) {
 
 		set.Remove(3)
 		require.Equal(t, 2, set.Length())
-		require.Nil(t, set.Get(3))
+
+		v, exists := set.Get(3)
+		require.Nil(t, v)
+		require.False(t, exists)
 	})
 
 	t.Run("middle value", func(t *testing.T) {
@@ -72,7 +85,10 @@ func TestRemove(t *testing.T) {
 
 		set.Remove(2)
 		require.Equal(t, 2, set.Length())
-		require.Nil(t, set.Get(2))
+
+		v, exists := set.Get(2)
+		require.Nil(t, v)
+		require.False(t, exists)
 	})
 
 	t.Run("single value", func(t *testing.T) {
@@ -80,6 +96,9 @@ func TestRemove(t *testing.T) {
 		set.Put(1, 1)
 		set.Remove(1)
 		require.Equal(t, 0, set.Length())
-		require.Nil(t, set.Get(1))
+
+		v, exists := set.Get(1)
+		require.Nil(t, v)
+		require.False(t, exists)
 	})
 }

--- a/linkedhashset.go
+++ b/linkedhashset.go
@@ -61,6 +61,7 @@ func (l *LinkedHashSet[T]) AsInterface() []interface{} {
 }
 
 // InArray returns whether the given item is in array or not
+// DEPRECATED: use Contains method instead
 func (l *LinkedHashSet[T]) InArray(search T) bool {
 	for item := range l.Iter() {
 		if item == search {
@@ -79,4 +80,9 @@ func NewLinkedHashSet[T comparable](items ...T) *LinkedHashSet[T] {
 		lhm.Add(items...)
 	}
 	return lhm
+}
+
+func (l *LinkedHashSet[T]) Contains(search T) bool {
+	_, contains := l.linkedHashMap.Get(search)
+	return contains
 }

--- a/linkedhashset_benchmark_test.go
+++ b/linkedhashset_benchmark_test.go
@@ -1,49 +1,55 @@
 package set
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func BenchmarkLinkedHashSet_Contains_vs_InArray(b *testing.B) {
-	set := NewLinkedHashSet[string]()
-	set.Add(giantGenericSlice...)
+	total := len(giantGenericSlice)
+	step := total / 5
+	sizes := []int{step, 2 * step, 3 * step, 4 * step, total}
 
-	foundTarget := giantGenericSlice[len(giantGenericSlice)/2]
-	notFoundTarget := "___not_present___"
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			set := NewLinkedHashSet[string]()
+			set.Add(giantGenericSlice[:n]...)
 
-	b.Run("Found", func(b *testing.B) {
-		b.Run("Contains", func(b *testing.B) {
-			b.ReportAllocs()
-			var sink bool
-			for i := 0; i < b.N; i++ {
-				sink = set.Contains(foundTarget)
-			}
-			_ = sink
-		})
-		b.Run("InArray", func(b *testing.B) {
-			b.ReportAllocs()
-			var sink bool
-			for i := 0; i < b.N; i++ {
-				sink = set.InArray(foundTarget)
-			}
-			_ = sink
-		})
-	})
+			foundTarget := giantGenericSlice[n/2]
+			notFoundTarget := "___not_present___"
 
-	b.Run("NotFound", func(b *testing.B) {
-		b.Run("Contains", func(b *testing.B) {
-			b.ReportAllocs()
-			var sink bool
-			for i := 0; i < b.N; i++ {
-				sink = set.Contains(notFoundTarget)
-			}
-			_ = sink
+			b.Run("Found/Contains", func(b *testing.B) {
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					sink = set.Contains(foundTarget)
+				}
+				_ = sink
+			})
+			b.Run("Found/InArray", func(b *testing.B) {
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					sink = set.InArray(foundTarget)
+				}
+				_ = sink
+			})
+			b.Run("NotFound/Contains", func(b *testing.B) {
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					sink = set.Contains(notFoundTarget)
+				}
+				_ = sink
+			})
+			b.Run("NotFound/InArray", func(b *testing.B) {
+				b.ReportAllocs()
+				var sink bool
+				for i := 0; i < b.N; i++ {
+					sink = set.InArray(notFoundTarget)
+				}
+				_ = sink
+			})
 		})
-		b.Run("InArray", func(b *testing.B) {
-			b.ReportAllocs()
-			var sink bool
-			for i := 0; i < b.N; i++ {
-				sink = set.InArray(notFoundTarget)
-			}
-			_ = sink
-		})
-	})
+	}
 }

--- a/linkedhashset_benchmark_test.go
+++ b/linkedhashset_benchmark_test.go
@@ -1,0 +1,49 @@
+package set
+
+import "testing"
+
+func BenchmarkLinkedHashSet_Contains_vs_InArray(b *testing.B) {
+	set := NewLinkedHashSet[string]()
+	set.Add(giantGenericSlice...)
+
+	foundTarget := giantGenericSlice[len(giantGenericSlice)/2]
+	notFoundTarget := "___not_present___"
+
+	b.Run("Found", func(b *testing.B) {
+		b.Run("Contains", func(b *testing.B) {
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				sink = set.Contains(foundTarget)
+			}
+			_ = sink
+		})
+		b.Run("InArray", func(b *testing.B) {
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				sink = set.InArray(foundTarget)
+			}
+			_ = sink
+		})
+	})
+
+	b.Run("NotFound", func(b *testing.B) {
+		b.Run("Contains", func(b *testing.B) {
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				sink = set.Contains(notFoundTarget)
+			}
+			_ = sink
+		})
+		b.Run("InArray", func(b *testing.B) {
+			b.ReportAllocs()
+			var sink bool
+			for i := 0; i < b.N; i++ {
+				sink = set.InArray(notFoundTarget)
+			}
+			_ = sink
+		})
+	})
+}

--- a/linkedhashset_test.go
+++ b/linkedhashset_test.go
@@ -200,8 +200,6 @@ func TestLinkedHashSetAsInterface(t *testing.T) {
 func TestLinkedHashSetContains(t *testing.T) {
 	t.Run("found", func(t *testing.T) {
 		set := NewLinkedHashSet("02", "04", "06", "08")
-		println(set.linkedHashMap.table)
-		println(set.linkedHashMap.Get("02")) // debug
 
 		require.True(t, set.Contains("02"))
 		require.True(t, set.Contains("04"))

--- a/linkedhashset_test.go
+++ b/linkedhashset_test.go
@@ -196,3 +196,32 @@ func TestLinkedHashSetAsInterface(t *testing.T) {
 		require.Equal(t, value.(testStruct), expectedArray[i])
 	}
 }
+
+func TestLinkedHashSetContains(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		set := NewLinkedHashSet("02", "04", "06", "08")
+		println(set.linkedHashMap.table)
+		println(set.linkedHashMap.Get("02")) // debug
+
+		require.True(t, set.Contains("02"))
+		require.True(t, set.Contains("04"))
+		require.True(t, set.Contains("06"))
+		require.True(t, set.Contains("08"))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		set := NewLinkedHashSet("02", "04", "06", "08")
+		require.False(t, set.Contains("01"))
+		require.False(t, set.Contains("03"))
+		require.False(t, set.Contains("05"))
+		require.False(t, set.Contains("07"))
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		set := NewLinkedHashSet[string]()
+		require.False(t, set.Contains("01"))
+		require.False(t, set.Contains("03"))
+		require.False(t, set.Contains("05"))
+		require.False(t, set.Contains("07"))
+	})
+}


### PR DESCRIPTION
## Problema

Método InArray verifica existencia de um item no set, no entanto ele itera por todo o set, por isso sua complexidade é O(n); 

Aproveitando o método Get que usa tabela hash foi implementado o método Contains, que resolve o problema em O(1) (desconsiderando colisões de hash aqui)

## Benchmark

| N      | Caso     | Contains (ns/op) | InArray (ns/op) | Contains (B/op) | InArray (B/op) |
|--------|----------|------------------|-----------------|-----------------|----------------|
| 20000  | Found    | 159.0            | 1,300,429       | 24              | 491,804       |
| 20000  | NotFound | 242.6            | 1,782,240       | 40              | 491,781        |
| 40000  | Found    | 155.8            | 2,409,341       | 24              | 975,117        | 
| 40000  | NotFound | 225.8            | 3,536,619       | 40              | 975,124        | 
| 60000  | Found    | 186.4            | 4,663,344       | 24              | 1,450,258      | 
| 60000  | NotFound | 239.0            | 6,492,405       | 40              | 1,450,237      | 
| 80000  | Found    | 160.5            | 5,832,141       | 24              | 1,933,580      | 
| 80000  | NotFound | 264.6            | 8,301,901       | 40              | 1,933,565      |
| 100000 | Found    | 163.2            | 7,531,702       | 24              | 2,408,700      | 
| 100000 | NotFound | 236.5            | 10,035,038      | 40              | 2,408,730      |

<img width="1572" height="1180" alt="image" src="https://github.com/user-attachments/assets/d2b83ec1-5e95-49ee-9253-0f4dc25fa1e6" />

<img width="1979" height="1180" alt="image" src="https://github.com/user-attachments/assets/b7d17e99-00dc-4d84-aa1f-f0b81aaab61e" />



```
Running tool: /usr/bin/go test -benchmem -run=^$ -bench ^BenchmarkLinkedHashSet_Contains_vs_InArray$ github.com/StudioSol/set

goos: linux
goarch: amd64
pkg: github.com/StudioSol/set
cpu: 11th Gen Intel(R) Core(TM) i7-11390H @ 3.40GHz
BenchmarkLinkedHashSet_Contains_vs_InArray/N=20000/Found/Contains-8         	 7893087	       159.0 ns/op	      24 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=20000/Found/InArray-8          	     960	   1300429 ns/op	  491804 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=20000/NotFound/Contains-8      	 5032278	       242.6 ns/op	      40 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=20000/NotFound/InArray-8       	     644	   1782240 ns/op	  491781 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=40000/Found/Contains-8         	 7268748	       155.8 ns/op	      24 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=40000/Found/InArray-8          	     505	   2409341 ns/op	  975117 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=40000/NotFound/Contains-8      	 5115067	       225.8 ns/op	      40 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=40000/NotFound/InArray-8       	     367	   3536619 ns/op	  975124 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=60000/Found/Contains-8         	 6690541	       186.4 ns/op	      24 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=60000/Found/InArray-8          	     264	   4663344 ns/op	 1450258 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=60000/NotFound/Contains-8      	 4386883	       239.0 ns/op	      40 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=60000/NotFound/InArray-8       	     193	   6492405 ns/op	 1450237 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=80000/Found/Contains-8         	 6602422	       160.5 ns/op	      24 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=80000/Found/InArray-8          	     218	   5832141 ns/op	 1933580 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=80000/NotFound/Contains-8      	 4031731	       264.6 ns/op	      40 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=80000/NotFound/InArray-8       	     145	   8301901 ns/op	 1933565 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=100000/Found/Contains-8        	 6620458	       163.2 ns/op	      24 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=100000/Found/InArray-8         	     165	   7531702 ns/op	 2408700 B/op	       6 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=100000/NotFound/Contains-8     	 4256808	       236.5 ns/op	      40 B/op	       2 allocs/op
BenchmarkLinkedHashSet_Contains_vs_InArray/N=100000/NotFound/InArray-8      	     100	  10035038 ns/op	 2408730 B/op	       6 allocs/op
PASS
ok  	github.com/StudioSol/set	30.082s
```

